### PR TITLE
fix: tcp: handle port reuse by splitting streams on new SYN

### DIFF
--- a/reassembly/memory.go
+++ b/reassembly/memory.go
@@ -186,6 +186,15 @@ func (p *StreamPool) getConnection(k key, end bool, ts time.Time, tcp *layers.TC
 	p.mu.RLock()
 	conn, half, rev := p.getHalf(k)
 	p.mu.RUnlock()
+
+	// handle port reuse
+	if conn != nil && tcp.SYN && !tcp.ACK {
+		p.mu.Lock()
+		delete(p.conns, k)
+		p.mu.Unlock()
+		conn = nil
+	}
+
 	if end || conn != nil {
 		return conn, half, rev
 	}

--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -754,7 +754,7 @@ func (a *Assembler) AssembleWithContext(packet gopacket.Packet, t *layers.TCP, a
 		}
 	}
 
-	action = a.handleBytes(bytes, seq, half, t.SYN, t.RST || t.FIN, action, ac)
+	action = a.handleBytes(bytes, seq, half, t.SYN, t.RST, action, ac)
 	if len(a.ret) > 0 {
 		action.nextSeq = a.sendToConnection(conn, half, ac)
 	}


### PR DESCRIPTION
When a new SYN (without ACK) is seen for an existing connection, it indicates that the same 4-tuple is being reused for a new TCP connection. Previously, these packets were appended to the old stream, causing mixing of two connections.

This change removes the old connection from the pool when a new SYN is seen, ensuring that short-time port reuse is correctly treated as a separate stream.